### PR TITLE
fix command not found error

### DIFF
--- a/virtualreality/main.py
+++ b/virtualreality/main.py
@@ -27,7 +27,7 @@ def main():
         from virtualreality.calibration.manual_color_mask_calibration import main
 
         main()
-    if args["<command>"] == "calibrate-cam":
+    elif args["<command>"] == "calibrate-cam":
         from virtualreality.calibration.camera_calibration import main
 
         main()


### PR DESCRIPTION
Fix bug where using pyvr calibrate would print "command not found error" and halt execution